### PR TITLE
feat: implement custom query parameters parser policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+*.class
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.ear
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+# Maven files
+/target/
+
+# Idea files
+/.idea/
+/*.iml
+
+.DS_Store

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,2 @@
+printWidth: 140
+tabWidth: 4

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.adoc
+++ b/README.adoc
@@ -1,0 +1,52 @@
+= Custom Query Parameters Parser policy
+
+ifdef::env-github[]
+image:https://img.shields.io/static/v1?label=Available%20at&message=Gravitee.io&color=1EC9D2["Gravitee.io", link="https://download.gravitee.io/#graviteeio-apim/plugins/policies/gravitee-policy-custom-query-parameters-parser/"]
+image:https://img.shields.io/badge/License-Apache%202.0-blue.svg["License", link="https://github.com/gravitee-io/gravitee-policy-custom-query-parameters-parser/blob/master/LICENSE.txt"]
+image:https://img.shields.io/badge/semantic--release-conventional%20commits-e10079?logo=semantic-release["Releases", link="https://github.com/gravitee-io/gravitee-policy-custom-query-parameters-parser/releases"]
+endif::[]
+
+== Phase
+
+[cols="^2,^2,^2,^2",options="header"]
+|===
+|onRequest|onResponse|onRequestContent|onResponseContent
+
+|X
+|
+|
+|
+
+|===
+
+== Description
+
+You can use the `custom-query-parameters-parser` policy to set variables such as request attributes and other execution context attributes.
+
+You can use it to change the way query parameters are extracted.
+
+Semicolon character (`;`) is not considered as a separator:
+
+`http://host:port/my-api?filter=field1;field2` will be computed with this query param: `filter: ['field1;field']`
+
+WARNING: Policies are executed after flow evaluation: for a condition on a flow using Expression Language to test query parameters, they will be extracted the regular way by the Gateway, with `;` as a separator.
+
+== Compatibility with APIM
+
+|===
+| Plugin version | APIM version
+
+| Up to 1.x      | 3.20.x to latest
+|===
+
+== Errors
+
+=== HTTP status code
+
+|===
+|Code |Message
+
+.^| ```500```
+| An error occurred while extracting query parameters from request url.
+
+|===

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,178 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.gravitee.policy</groupId>
+    <artifactId>gravitee-policy-custom-query-parameters-parser</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <name>Gravitee.io APIM - Policy - Custom Query Parameters Parser</name>
+    <description>Extract query parameters from request uri in a custom way</description>
+
+    <parent>
+        <groupId>io.gravitee</groupId>
+        <artifactId>gravitee-parent</artifactId>
+        <version>20.4</version>
+    </parent>
+
+    <properties>
+        <gravitee-bom.version>3.0.0</gravitee-bom.version>
+        <gravitee-apim-gateway-tests-sdk.version>3.20.16</gravitee-apim-gateway-tests-sdk.version>
+        <gravitee-gateway-api.version>2.0.1</gravitee-gateway-api.version>
+        <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
+        <gravitee-common.version>2.3.0-apim-2218-semicolon-query-params-SNAPSHOT</gravitee-common.version>
+
+        <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
+        <!-- Property used by the publication job in CI-->
+        <publish-folder-path>graviteeio-apim/plugins/policies</publish-folder-path>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Import bom to properly inherit all dependencies -->
+            <dependency>
+                <groupId>io.gravitee</groupId>
+                <artifactId>gravitee-bom</artifactId>
+                <version>${gravitee-bom.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <!-- Gravitee.io dependencies -->
+        <dependency>
+            <groupId>io.gravitee.gateway</groupId>
+            <artifactId>gravitee-gateway-api</artifactId>
+            <version>${gravitee-gateway-api.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.gravitee.policy</groupId>
+            <artifactId>gravitee-policy-api</artifactId>
+            <version>${gravitee-policy-api.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.gravitee.common</groupId>
+            <artifactId>gravitee-common</artifactId>
+            <version>${gravitee-common.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Logging dependencies -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Test scope -->
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.gravitee.apim.gateway</groupId>
+            <artifactId>gravitee-apim-gateway-tests-sdk</artifactId>
+            <version>${gravitee-apim-gateway-tests-sdk.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>properties-maven-plugin</artifactId>
+                <version>1.0.0</version>
+                <executions>
+                    <execution>
+                        <phase>initialize</phase>
+                        <id>load-plugin-properties</id>
+                        <goals>
+                            <goal>read-project-properties</goal>
+                        </goals>
+                        <configuration>
+                            <files>
+                                <file>${project.basedir}/src/main/resources/plugin.properties</file>
+                            </files>
+                            <quiet>false</quiet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>${maven-assembly-plugin.version}</version>
+                <configuration>
+                    <appendAssemblyId>false</appendAssemblyId>
+                    <descriptors>
+                        <descriptor>src/assembly/policy-assembly.xml</descriptor>
+                    </descriptors>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-policy-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.hubspot.maven.plugins</groupId>
+                <artifactId>prettier-maven-plugin</artifactId>
+                <version>0.17</version>
+                <configuration>
+                    <nodeVersion>12.13.0</nodeVersion>
+                    <prettierJavaVersion>1.6.1</prettierJavaVersion>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
     <groupId>io.gravitee.policy</groupId>
     <artifactId>gravitee-policy-custom-query-parameters-parser</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0.0</version>
     <name>Gravitee.io APIM - Policy - Custom Query Parameters Parser</name>
     <description>Extract query parameters from request uri in a custom way</description>
 
@@ -35,10 +35,10 @@
 
     <properties>
         <gravitee-bom.version>3.0.0</gravitee-bom.version>
-        <gravitee-apim-gateway-tests-sdk.version>3.20.16</gravitee-apim-gateway-tests-sdk.version>
+        <gravitee-apim-gateway-tests-sdk.version>3.20.17</gravitee-apim-gateway-tests-sdk.version>
         <gravitee-gateway-api.version>2.0.1</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
-        <gravitee-common.version>2.3.0-apim-2218-semicolon-query-params-SNAPSHOT</gravitee-common.version>
+        <gravitee-common.version>2.3.0</gravitee-common.version>
 
         <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
         <!-- Property used by the publication job in CI-->

--- a/src/assembly/policy-assembly.xml
+++ b/src/assembly/policy-assembly.xml
@@ -1,0 +1,74 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
+    <id>policy</id>
+    <formats>
+        <format>zip</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+
+    <!-- Include the main Policy Jar file -->
+    <files>
+        <file>
+            <source>${project.build.directory}/${project.build.finalName}.jar</source>
+        </file>
+    </files>
+
+    <fileSets>
+        <!-- Then include Policy configuration schemas -->
+        <fileSet>
+            <directory>src/main/resources/schemas</directory>
+            <outputDirectory>schemas</outputDirectory>
+        </fileSet>
+
+        <fileSet>
+            <directory>${basedir}</directory>
+            <includes>
+                <include>README.adoc</include>
+            </includes>
+            <outputDirectory>docs</outputDirectory>
+        </fileSet>
+
+        <fileSet>
+            <directory>${basedir}</directory>
+            <includes>
+                <include>${icon}</include>
+            </includes>
+        </fileSet>
+
+        <!-- Create the empty lib directory in case of no libraries is required -->
+        <!-- As there is no maven-assembly-plugin's method do to that, we hack it ourself -->
+        <fileSet>
+            <directory>${project.basedir}/src/assembly</directory>
+            <outputDirectory>lib</outputDirectory>
+            <excludes>
+                <exclude>*</exclude>
+            </excludes>
+        </fileSet>
+    </fileSets>
+
+    <!-- Finally include Policy dependencies -->
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>lib</outputDirectory>
+            <useProjectArtifact>false</useProjectArtifact>
+        </dependencySet>
+    </dependencySets>
+</assembly>

--- a/src/main/java/io/gravitee/policy/customqueryparametersparser/CustomQueryParametersParserPolicy.java
+++ b/src/main/java/io/gravitee/policy/customqueryparametersparser/CustomQueryParametersParserPolicy.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.customqueryparametersparser;
+
+import io.gravitee.gateway.jupiter.api.context.HttpExecutionContext;
+import io.gravitee.gateway.jupiter.api.policy.Policy;
+import io.gravitee.policy.v3.customqueryparametersparser.CustomQueryParametersParserPolicyV3;
+import io.reactivex.rxjava3.core.Completable;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class CustomQueryParametersParserPolicy extends CustomQueryParametersParserPolicyV3 implements Policy {
+
+    public static final String POLICY_ID = "custom-query-parameters-parser";
+
+    @Override
+    public String id() {
+        return POLICY_ID;
+    }
+
+    @Override
+    public Completable onRequest(HttpExecutionContext ctx) {
+        parseParameters(ctx.request().uri(), ctx.request().parameters());
+        return Completable.complete();
+    }
+}

--- a/src/main/java/io/gravitee/policy/v3/customqueryparametersparser/CustomQueryParametersParserPolicyV3.java
+++ b/src/main/java/io/gravitee/policy/v3/customqueryparametersparser/CustomQueryParametersParserPolicyV3.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.v3.customqueryparametersparser;
+
+import io.gravitee.common.util.MultiValueMap;
+import io.gravitee.common.util.URIUtils;
+import io.gravitee.gateway.api.ExecutionContext;
+import io.gravitee.policy.api.PolicyChain;
+import io.gravitee.policy.api.annotations.OnRequest;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class CustomQueryParametersParserPolicyV3 {
+
+    @OnRequest
+    public void onRequest(ExecutionContext executionContext, PolicyChain policyChain) {
+        parseParameters(executionContext.request().uri(), executionContext.request().parameters());
+        policyChain.doNext(executionContext.request(), executionContext.response());
+    }
+
+    public static void parseParameters(String uri, MultiValueMap<String, String> parameters) {
+        if (uri.contains(";")) {
+            parameters.clear();
+            parameters.putAll(URIUtils.parameters(uri, true));
+        }
+    }
+}

--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -1,0 +1,8 @@
+id=custom-query-parameters-parser
+name=Custom query parameters parser
+version=${project.version}
+description=${project.description}
+class=io.gravitee.policy.customqueryparameterparser.CustomQueryParametersParserPolicy
+type=policy
+category=transformation
+proxy=REQUEST

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -1,0 +1,5 @@
+{
+  "type" : "object",
+  "id" : "urn:jsonschema:CustomQueryParametersParser",
+  "properties" : {}
+}

--- a/src/test/java/io/gravitee/policy/customqueryparametersparser/CustomQueryParametersParserPolicyIntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/customqueryparametersparser/CustomQueryParametersParserPolicyIntegrationTest.java
@@ -1,0 +1,110 @@
+package io.gravitee.policy.customqueryparametersparser;/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static io.gravitee.policy.customqueryparametersparser.CustomQueryParametersParserPolicy.POLICY_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayMode;
+import io.gravitee.apim.gateway.tests.sdk.policy.PolicyBuilder;
+import io.gravitee.common.util.LinkedMultiValueMap;
+import io.gravitee.common.util.MultiValueMap;
+import io.gravitee.plugin.policy.PolicyPlugin;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.rxjava3.core.http.HttpClient;
+import io.vertx.rxjava3.core.http.HttpClientRequest;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import policies.QueryParamsToHeaderPolicy;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@GatewayTest(mode = GatewayMode.JUPITER)
+@DeployApi("/apis/api.json")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class CustomQueryParametersParserPolicyIntegrationTest extends AbstractGatewayTest {
+
+    @Override
+    public void configurePolicies(Map<String, PolicyPlugin> policies) {
+        policies.put(POLICY_ID, PolicyBuilder.build(POLICY_ID, CustomQueryParametersParserPolicy.class));
+        policies.put("query-params-to-header", PolicyBuilder.build("query-params-to-header", QueryParamsToHeaderPolicy.class));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideArguments")
+    public void should_preserve_query_params_and_extract_them_properly(
+        String query,
+        MultiValueMap<String, String> expectedQueryParameters,
+        HttpClient client
+    ) throws Exception {
+        wiremock.stubFor(get("/team" + query).willReturn(ok()));
+
+        client
+            .rxRequest(HttpMethod.GET, "/test" + query)
+            .flatMap(HttpClientRequest::rxSend)
+            .test()
+            .await()
+            .assertComplete()
+            .assertValue(response -> {
+                assertThat(response.statusCode()).isEqualTo(200);
+                expectedQueryParameters.forEach((expectedKey, expectedValue) -> {
+                    assertThat(response.headers().contains(expectedKey)).isTrue();
+                    // The policy is doing a toString to fill the headers, so we need to handle the null case
+                    assertThat(response.headers().get(expectedKey))
+                        .isEqualTo(expectedValue.isEmpty() ? "[null]" : expectedValue.toString());
+                });
+                return true;
+            })
+            .assertNoErrors();
+
+        wiremock.verify(1, getRequestedFor(urlEqualTo("/team" + query)));
+    }
+
+    public Stream<Arguments> provideArguments() {
+        return Stream.of(
+            Arguments.of("", new LinkedMultiValueMap<>()),
+            Arguments.of("?filter=field1", new LinkedMultiValueMap<>(Map.of("filter", List.of("field1")))),
+            Arguments.of("?filter=field1&filter=field2", new LinkedMultiValueMap<>(Map.of("filter", List.of("field1", "field2")))),
+            Arguments.of("?filter=field1&asc", new LinkedMultiValueMap<>(Map.of("filter", List.of("field1"), "asc", List.of()))),
+            Arguments.of(
+                "?filter=200-299;300-399;500-599",
+                new LinkedMultiValueMap<>(Map.of("filter", List.of("200-299;300-399;500-599")))
+            ),
+            Arguments.of(
+                "?tagNames=GIO%20APIM%20GW*;GIO%20%20APIM%20REST*",
+                new LinkedMultiValueMap<>(Map.of("tagNames", List.of("GIO%20APIM%20GW*;GIO%20A%20PIM%20REST*")))
+            ),
+            Arguments.of(
+                "?$expand=Person($select=SaleChannel,Id;$expand=age)",
+                new LinkedMultiValueMap<>(Map.of("$expand", List.of("Person($select=SaleChannel,Id;$expand=age)")))
+            )
+        );
+    }
+}

--- a/src/test/java/io/gravitee/policy/customqueryparametersparser/CustomQueryParametersParserPolicyIntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/customqueryparametersparser/CustomQueryParametersParserPolicyIntegrationTest.java
@@ -98,8 +98,8 @@ public class CustomQueryParametersParserPolicyIntegrationTest extends AbstractGa
                 new LinkedMultiValueMap<>(Map.of("filter", List.of("200-299;300-399;500-599")))
             ),
             Arguments.of(
-                "?tagNames=GIO%20APIM%20GW*;GIO%20%20APIM%20REST*",
-                new LinkedMultiValueMap<>(Map.of("tagNames", List.of("GIO%20APIM%20GW*;GIO%20A%20PIM%20REST*")))
+                "?tagNames=GIO%20APIM%20GW*;GIO%20APIM%20REST*",
+                new LinkedMultiValueMap<>(Map.of("tagNames", List.of("GIO%20APIM%20GW*;GIO%20APIM%20REST*")))
             ),
             Arguments.of(
                 "?$expand=Person($select=SaleChannel,Id;$expand=age)",

--- a/src/test/java/io/gravitee/policy/customqueryparametersparser/CustomQueryParametersParserPolicyV3CompatibilityIntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/customqueryparametersparser/CustomQueryParametersParserPolicyV3CompatibilityIntegrationTest.java
@@ -1,0 +1,25 @@
+package io.gravitee.policy.customqueryparametersparser;/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayMode;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@GatewayTest(mode = GatewayMode.COMPATIBILITY)
+public class CustomQueryParametersParserPolicyV3CompatibilityIntegrationTest extends CustomQueryParametersParserPolicyIntegrationTest {}

--- a/src/test/java/io/gravitee/policy/customqueryparametersparser/CustomQueryParametersParserPolicyV3IntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/customqueryparametersparser/CustomQueryParametersParserPolicyV3IntegrationTest.java
@@ -1,0 +1,25 @@
+package io.gravitee.policy.customqueryparametersparser;/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayMode;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@GatewayTest(mode = GatewayMode.V3)
+public class CustomQueryParametersParserPolicyV3IntegrationTest extends CustomQueryParametersParserPolicyIntegrationTest {}

--- a/src/test/java/policies/QueryParamsToHeaderPolicy.java
+++ b/src/test/java/policies/QueryParamsToHeaderPolicy.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package policies;/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import io.gravitee.gateway.jupiter.api.context.HttpExecutionContext;
+import io.gravitee.gateway.jupiter.api.context.HttpRequest;
+import io.gravitee.gateway.jupiter.api.context.HttpResponse;
+import io.gravitee.gateway.jupiter.api.policy.Policy;
+import io.reactivex.rxjava3.core.Completable;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class QueryParamsToHeaderPolicy extends QueryParamsToHeaderPolicyV3 implements Policy {
+
+    @Override
+    public String id() {
+        return "query-params-to-header";
+    }
+
+    @Override
+    public Completable onResponse(HttpExecutionContext ctx) {
+        final HttpRequest request = ctx.request();
+        final HttpResponse response = ctx.response();
+        if (request.parameters() != null) {
+            request.parameters().forEach((key, value) -> response.headers().set(key, value.toString()));
+        }
+        return Completable.complete();
+    }
+}

--- a/src/test/java/policies/QueryParamsToHeaderPolicyV3.java
+++ b/src/test/java/policies/QueryParamsToHeaderPolicyV3.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package policies;/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import io.gravitee.gateway.api.Request;
+import io.gravitee.gateway.api.Response;
+import io.gravitee.policy.api.PolicyChain;
+import io.gravitee.policy.api.annotations.OnResponse;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class QueryParamsToHeaderPolicyV3 {
+
+    @OnResponse
+    public void onResponse(Request request, Response response, PolicyChain policyChain) {
+        if (request.parameters() != null) {
+            request.parameters().forEach((key, value) -> response.headers().set(key, value.toString()));
+        }
+        policyChain.doNext(request, response);
+    }
+}

--- a/src/test/resources/apis/api.json
+++ b/src/test/resources/apis/api.json
@@ -1,0 +1,50 @@
+{
+  "id": "my-api",
+  "name": "my-api",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/test",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:8080/team",
+        "http": {
+          "connectTimeout": 3000,
+          "readTimeout": 60000
+        }
+      }
+    ]
+  },
+  "flows": [
+    {
+      "name": "flow-1",
+      "methods": [
+        "GET"
+      ],
+      "enabled": true,
+      "path-operator": {
+        "path": "/",
+        "operator": "STARTS_WITH"
+      },
+      "pre": [
+        {
+          "name": "Compute query param to accept ; as a normal char",
+          "description": "",
+          "enabled": true,
+          "policy": "custom-query-parameters-parser",
+          "configuration": {}
+        }
+      ],
+      "post": [
+        {
+          "name": "Query params to header",
+          "description": "",
+          "enabled": true,
+          "policy": "query-params-to-header",
+          "configuration": {}
+        }
+      ]
+    }
+  ],
+  "resources": []
+}

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright (c) 2015-2016, The Gravitee team (http://www.gravitee.io)
+  ~
+  ~  Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~  http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
+  -->
+
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{5} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="io.gravitee" level="DEBUG" additivity="false">
+        <appender-ref ref="STDOUT" />
+    </logger>
+
+    <!-- Strictly speaking, the level attribute is not necessary since -->
+    <!-- the level of the root level is set to DEBUG by default.       -->
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+</configuration>


### PR DESCRIPTION

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.0.0`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-custom-query-parameters-parser/1.0.0/gravitee-policy-custom-query-parameters-parser-1.0.0.zip)
  <!-- Version placeholder end -->
